### PR TITLE
Add functions to expose the x and y scales for external use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ If <i>nodeSize</i> is set, returns the current <i>nodeSize</i>.
 
 If instead [size](#size) is set, returns the actual size of a node <i>after</i> [grid](#grid) has been called.
 
+<a name="xScale" href="#xScale">#</a> grid.<b>xScale</b>()
+
+Returns the x scale used by this instance.
+
+<a name="yScale" href="#yScale">#</a> grid.<b>yScale</b>()
+
+Returns the y scale used by this instance.
+
 
 ## Examples
 

--- a/d3-grid.js
+++ b/d3-grid.js
@@ -118,6 +118,10 @@
       return grid;
     }
 
+    grid.xScale = function() { return x }
+
+    grid.yScale = function() { return y }
+
     return grid;
   };
 })();


### PR DESCRIPTION
I'm very new to this stuff, so please educate me if there's a better way.

That said, I found that I wanted to put labels beside the x and y axes, and needed to find out what the correct x and y positions were for a given row or column.  It seemed like the best way was to use the same scale object that the grid object was itself using.  So I added functions to expose those scales to the outside. Is this reasonable?
