### PR TITLE
Add row and col fields to nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Computes the layout for <i>nodes</i>. Per default, the layout tries to keep the 
 * x – the computed <i>x</i>-coordinate of the node position.
 * y – the computed <i>y</i>-coordinate of the node position.
 
+In addition, <i>row</i> and <i>col</i> are added to each node so that they can be queried and used, for example,
+to look up row- or column-specific data.
+
 <a name="points" href="#points">#</a> grid.<b>points</b>()
 
 Configure the grid to treat nodes as points, cf. [d3.scale.ordinal().rangePoints()](https://github.com/mbostock/d3/wiki/Ordinal-Scales#wiki-ordinal_rangePoints).

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ If <i>nodeSize</i> is set, returns the current <i>nodeSize</i>.
 
 If instead [size](#size) is set, returns the actual size of a node <i>after</i> [grid](#grid) has been called.
 
+<a name="xScale" href="#xScale">#</a> grid.<b>xScale</b>()
+
+Returns the x scale used by this instance.
+
+<a name="yScale" href="#yScale">#</a> grid.<b>yScale</b>()
+
+Returns the y scale used by this instance.
+
 
 ## Examples
 

--- a/d3-grid.js
+++ b/d3-grid.js
@@ -118,6 +118,10 @@
       return grid;
     }
 
+    grid.xScale = function() { return x }
+
+    grid.yScale = function() { return y }
+
     return grid;
   };
 })();

--- a/d3-grid.js
+++ b/d3-grid.js
@@ -61,6 +61,9 @@
 
         nodes[i].x = x(col);
         nodes[i].y = y(row);
+
+        nodes[i].col = col;
+        nodes[i].row = row;
       }
 
       return nodes;


### PR DESCRIPTION
It can be helpful for a node to know its row and column, for example, to look up information specific to that row or column, for use in a tooltip, creation of a URL in a tooltip, etc.

This mod adds those fields.  I'm assuming the additional CPU overhead and required memory storage will not be significant.
